### PR TITLE
chore(vendor): update @lightbasenl/backend

### DIFF
--- a/vendor/backend/package.json
+++ b/vendor/backend/package.json
@@ -28,5 +28,5 @@
     "url": "https://github.com/lightbasenl/platform-components.git",
     "directory": "packages/backend"
   },
-  "gitHead": "2f1b97dd2c563f0c01d48019d46da867a3b7aa08"
+  "gitHead": "7105d3f7df4f5cf958106fdf0ff1ca4065cb4829"
 }

--- a/vendor/backend/src/feature-flag/events.js
+++ b/vendor/backend/src/feature-flag/events.js
@@ -28,7 +28,18 @@ export async function featureFlagCurrent(event) {
   const result = {};
 
   for (const flag of flags) {
+    if (!featureFlags.availableFlags.includes(flag.name)) {
+      // Don't return flags which are not yet known to this instance.
+      continue;
+    }
+
     result[flag.name] = flag.globalValue;
+  }
+
+  for (const flag of featureFlags.availableFlags) {
+    // Add flags which are not yet in the database, but are present in the config. These
+    // default to false
+    result[flag] ??= false;
   }
 
   eventStop(event);

--- a/vendor/backend/src/structure.js
+++ b/vendor/backend/src/structure.js
@@ -280,7 +280,12 @@ export async function extendWithBackendBase(app) {
     }),
 
     T.object("resolvedTenant").keys({
-      tenant: T.any().raw("QueryResultBackendTenant"),
+      tenant: T.any().implementations({
+        js: {
+          validatorInputType: "any",
+          validatorOutputType: "QueryResultBackendTenant",
+        },
+      }),
       urlConfig: T.reference("backend", "tenantUrlConfig"),
       publicUrl: T.string(),
       apiUrl: T.string(),


### PR DESCRIPTION

_This PR is created by sync and will be force-pushed daily. Overwriting any manual changes done to this PR._

<details> 
<summary>Click to expand the changelog</summary>

- fix(feature-flag): prevent invalid responses when starting a new api with a different set of feature flags

    We do rolling releases of all services. If a feature flag is added to
    the new service, the response of the old service would already include
    this new flag, erroring on strict response validation. This change makes
    sure that added or removed flags don't show up yet in the old api
    instance, based on the loaded feature flag config.


- chore(deps): bump to Compas v0.4.0
</details>
- Failed to execute `npx compas lint`. Sync is not able to correct this, so human checks and fixes are necessary for this PR.