### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "axios": "1.4.0",
     "form-data": "4.0.0",
     "mjml": "4.14.1",
-    "nodemailer": "6.9.3",
+    "nodemailer": "6.9.4",
     "nodemailer-html-to-text": "3.2.0"
   },
   "devDependencies": {
     "@compas/code-gen": "0.6.0",
     "@compas/eslint-plugin": "0.6.0",
     "@types/mjml": "4.7.1",
-    "@types/nodemailer": "6.4.8"
+    "@types/nodemailer": "6.4.9"
   },
   "prettier": "@compas/eslint-plugin/prettierrc",
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1694,10 +1694,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.2.tgz#129cc9ae69f93824f92fac653eebfb4812ab4af9"
   integrity sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==
 
-"@types/nodemailer@6.4.8":
-  version "6.4.8"
-  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.8.tgz#f06c661e9b201fc2acc3a00a0fded42ba7eaca9d"
-  integrity sha512-oVsJSCkqViCn8/pEu2hfjwVO+Gb3e+eTWjg3PcjeFKRItfKpKwHphQqbYmPQrlMk+op7pNNWPbsJIEthpFN/OQ==
+"@types/nodemailer@6.4.9":
+  version "6.4.9"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.9.tgz#38e22cc2e62006170df0966fb8762fbf5cec6cbf"
+  integrity sha512-XYG8Gv+sHjaOtUpiuytahMy2mM3rectgroNbs6R3djZEKmPNiIJwe9KqOJBGzKKnNZNKvnuvmugBgpq3w/S0ig==
   dependencies:
     "@types/node" "*"
 
@@ -4229,10 +4229,10 @@ nodemailer-html-to-text@3.2.0:
   dependencies:
     html-to-text "7.1.1"
 
-nodemailer@6.9.3:
-  version "6.9.3"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.3.tgz#e4425b85f05d83c43c5cd81bf84ab968f8ef5cbe"
-  integrity sha512-fy9v3NgTzBngrMFkDsKEj0r02U7jm6XfC3b52eoNV+GCrGj+s8pt5OqhiJdWKuw51zCTdiNR/IUD1z33LIIGpg==
+nodemailer@6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.4.tgz#93bd4a60eb0be6fa088a0483340551ebabfd2abf"
+  integrity sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==
 
 nopt@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION

_This PR is created by sync and will be force-pushed daily. Overwriting any manual changes done to this PR._

- Bumped @types/nodemailer (dev) from 6.4.8 to 6.4.9
- Bumped nodemailer from 6.9.3 to 6.9.4
  - Changelog: https://github.com/nodemailer/nodemailer/blob/-/CHANGELOG.md
