### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "axios": "1.5.0",
     "form-data": "4.0.0",
     "mjml": "4.14.1",
-    "nodemailer": "6.9.4",
+    "nodemailer": "6.9.5",
     "nodemailer-html-to-text": "3.2.0"
   },
   "devDependencies": {
     "@compas/code-gen": "0.7.3",
     "@compas/eslint-plugin": "0.7.3",
     "@types/mjml": "4.7.1",
-    "@types/nodemailer": "6.4.9"
+    "@types/nodemailer": "6.4.10"
   },
   "prettier": "@compas/eslint-plugin/prettierrc",
   "workspaces": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,10 +1707,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.7.tgz#4b8ecac87fbefbc92f431d09c30e176fc0a7c377"
   integrity sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==
 
-"@types/nodemailer@6.4.9":
-  version "6.4.9"
-  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.9.tgz#38e22cc2e62006170df0966fb8762fbf5cec6cbf"
-  integrity sha512-XYG8Gv+sHjaOtUpiuytahMy2mM3rectgroNbs6R3djZEKmPNiIJwe9KqOJBGzKKnNZNKvnuvmugBgpq3w/S0ig==
+"@types/nodemailer@6.4.10":
+  version "6.4.10"
+  resolved "https://registry.yarnpkg.com/@types/nodemailer/-/nodemailer-6.4.10.tgz#746c952d5f22e48efded93c0a5607f59c6369b4c"
+  integrity sha512-oPW/IdhkU3FyZc1dzeqmS+MBjrjZNiiINnrEOrWALzccJlP5xTlbkNr2YnTnnyj9Eqm5ofjRoASEbrCYpA7BrA==
   dependencies:
     "@types/node" "*"
 
@@ -4412,10 +4412,10 @@ nodemailer-html-to-text@3.2.0:
   dependencies:
     html-to-text "7.1.1"
 
-nodemailer@6.9.4:
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.4.tgz#93bd4a60eb0be6fa088a0483340551ebabfd2abf"
-  integrity sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==
+nodemailer@6.9.5:
+  version "6.9.5"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.9.5.tgz#eaeae949c62ec84ef1e9128df89fc146a1017aca"
+  integrity sha512-/dmdWo62XjumuLc5+AYQZeiRj+PRR8y8qKtFCOyuOl1k/hckZd8durUUHs/ucKx6/8kN+wFxqKJlQ/LK/qR5FA==
 
 nopt@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION

_This PR is created by sync and will be force-pushed daily. Overwriting any manual changes done to this PR._

- Bumped @types/nodemailer (dev) from 6.4.9 to 6.4.10
- Bumped nodemailer from 6.9.4 to 6.9.5
  - Changelog: https://github.com/nodemailer/nodemailer/blob/-/CHANGELOG.md
